### PR TITLE
Developの取り込み

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV IS_DOCKER=true\
     VOICES=""\
     EXCEPT_PREFIX=""\
     READ_NAME=""\
-    READ_SYSTEM_MESSAGE=""
+    READ_SYSTEM_MESSAGE=""\
+    READ_ALL_GUILD=""
 WORKDIR /root/discordjtalkbot
 CMD ["python3", "discordjtalkbot.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ ENV IS_DOCKER=true\
     TEXT_END=""\
     OPEN_JTALK_FLAGS=""\
     VOICES=""\
-    EXCEPT_PREFIX=""
+    EXCEPT_PREFIX=""\
+    READ_NAME=""\
+    READ_SYSTEM_MESSAGE=""
 WORKDIR /root/discordjtalkbot
 CMD ["python3", "discordjtalkbot.py"]

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ sudo env LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" pip3 install p
     "voices": "/usr/local/opt/open-jtalk/voice/m100/nitech_jp_atr503_m001.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_angry.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_bashful.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_happy.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_normal.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_sad.htsvoice",
     "except_prefix": "!,$,/",
     "read_name": "True",
-    "read_system_message": "True"
+    "read_system_message": "True",
+    "read_all_guild": "False"
   }
   ```
 
@@ -137,6 +138,9 @@ sudo env LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" pip3 install p
 
 文字列型。メンバーのボイスチャンネルへの入退室を読み上げるかどうか。設定がない場合は読み上げない("True"の時のみ読み上げる)
 
+#### `read_all_guild`
+
+文字列型。すべてのギルドのメッセージを読み上げるかどうか。設定がない場合はボイスチャンネルに接続したギルドのみ読み上げる
 ### Botの実行
 
  `python3 discordjtalkbot/discordJtalkbot.py` コマンドを実行します。  

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ sudo env LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" pip3 install p
     "text_start": "読み上げを始めます。",
     "text_end": "読み上げを終わります。",
     "voices": "/usr/local/opt/open-jtalk/voice/m100/nitech_jp_atr503_m001.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_angry.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_bashful.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_happy.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_normal.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_sad.htsvoice",
-    "except_prefix": "!,$,/"
+    "except_prefix": "!,$,/",
+    "read_name": "True",
+    "read_system_message": "True"
   }
   ```
 
@@ -126,6 +128,14 @@ sudo env LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" pip3 install p
 ##### `except_prefix`
 
 文字列型。指定したプレフィックスが先頭にあるメッセージは読み上げしないようになります(カンマ区切りで指定)。ギルドで使用しているBotのプレフィックスを指定すると良いと思います。
+
+##### `read_name`
+
+文字列型。名前を読み上げるかどうか。設定がない場合は読み上げない("True"の時のみ読み上げる)
+
+##### `read_system_message`
+
+文字列型。メンバーのボイスチャンネルへの入退室を読み上げるかどうか。設定がない場合は読み上げない("True"の時のみ読み上げる)
 
 ### Botの実行
 

--- a/discordjtalkbot/cogs/autoreadercog.py
+++ b/discordjtalkbot/cogs/autoreadercog.py
@@ -61,6 +61,9 @@ class AutoReaderCog(commands.Cog):
             vcl = discord.utils.get(
                 bot.voice_clients, channel__guild=tch.guild, channel__name=tch.name)
             if vcl:
+                # 何もなかったら無視
+                if len(msg.clean_content) == 0:
+                    return
                 # コマンドは無視
                 if msg.clean_content.startswith(await self.bot.get_prefix(msg)):
                     return
@@ -71,9 +74,11 @@ class AutoReaderCog(commands.Cog):
                     if msg.clean_content.startswith(ignore_command):
                         return
 
-                # 接続しているギルド以外は無視
-                if msg.guild != tch.guild:
-                    return
+                # 設定ファイルで設定されていれば、他のギルドも読み上げる
+                if not appenv.get('read_all_guild') == 'True':
+                    # 接続しているギルド以外は無視
+                    if msg.guild != tch.guild:
+                        return
 
                 LOG.info(f'!!Reading {msg.author}\'s post on t:{tch.guild}/{tch}!!.')
                 if msg.author.bot:
@@ -92,7 +97,6 @@ class AutoReaderCog(commands.Cog):
 
                 # 設定ファイルで設定されていれば、名前を読み上げる
                 if appenv.get('read_name') == 'True':
-                    LOG.info(f"read_name: {appenv.get('read_name')}")
                     message = f'{self.member_name}さん、' + message
                 await self.talk(vcl, message)
 

--- a/discordjtalkbot/cogs/modules/files/discordjtalkbot-config.sample.json
+++ b/discordjtalkbot/cogs/modules/files/discordjtalkbot-config.sample.json
@@ -5,5 +5,7 @@
     "text_start": "読み上げを始めます。",
     "text_end": "読み上げを終わります。",
     "voices": "/usr/local/opt/open-jtalk/voice/m100/nitech_jp_atr503_m001.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_angry.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_bashful.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_happy.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_normal.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_sad.htsvoice",
-    "except_prefix": "!,$,/"
+    "except_prefix": "!,$,/",
+    "read_name": "True",
+    "read_system_message": "True"
 }

--- a/discordjtalkbot/cogs/modules/files/discordjtalkbot-config.sample.json
+++ b/discordjtalkbot/cogs/modules/files/discordjtalkbot-config.sample.json
@@ -7,5 +7,6 @@
     "voices": "/usr/local/opt/open-jtalk/voice/m100/nitech_jp_atr503_m001.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_angry.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_bashful.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_happy.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_normal.htsvoice,/usr/local/opt/open-jtalk/voice/mei/mei_sad.htsvoice",
     "except_prefix": "!,$,/",
     "read_name": "True",
-    "read_system_message": "True"
+    "read_system_message": "True",
+    "read_all_guild": "False"
 }

--- a/discordjtalkbot/discordjtalkbot.py
+++ b/discordjtalkbot/discordjtalkbot.py
@@ -143,6 +143,10 @@ if __name__ == "__main__":
                         help='voices  (%(default)s)')
         appenv.add_field('except_prefix', default='$',
                         help='ignore prefix charactor  (%(default)s)')
+        appenv.add_field('read_name', default='False',
+                        help="read message author's name")
+        appenv.add_field('read_system_message', default='False',
+                        help="read system messsage")
 
         # environment variables
         BOT_NAME = 'discordjtalkbot'
@@ -173,6 +177,10 @@ if __name__ == "__main__":
                 env_list.extend(['--voices', os.getenv('VOICES')])
             if os.getenv('EXCEPT_PREFIX'):
                 env_list.extend(['--except_prefix', os.getenv('EXCEPT_PREFIX')])
+            if os.getenv('READ_NAME'):
+                env_list.extend(['--read_name', os.getenv('READ_NAME')])
+            if os.getenv('READ_SYSTEM_MESSAGE'):
+                env_list.extend(['--read_system_message', os.getenv('READ_SYSTEM_MESSAGE')])
             if env_list:
                 LOG.info(env_list)
                 appenv.load_args(env_list)

--- a/discordjtalkbot/discordjtalkbot.py
+++ b/discordjtalkbot/discordjtalkbot.py
@@ -147,6 +147,8 @@ if __name__ == "__main__":
                         help="read message author's name")
         appenv.add_field('read_system_message', default='False',
                         help="read system messsage")
+        appenv.add_field('read_all_guild', default='False',
+                        help="read all guild messsage")
 
         # environment variables
         BOT_NAME = 'discordjtalkbot'
@@ -181,6 +183,8 @@ if __name__ == "__main__":
                 env_list.extend(['--read_name', os.getenv('READ_NAME')])
             if os.getenv('READ_SYSTEM_MESSAGE'):
                 env_list.extend(['--read_system_message', os.getenv('READ_SYSTEM_MESSAGE')])
+            if os.getenv('READ_ALL_GUILD'):
+                env_list.extend(['--read_all_guild', os.getenv('READ_ALL_GUILD')])
             if env_list:
                 LOG.info(env_list)
                 appenv.load_args(env_list)


### PR DESCRIPTION
## 以下の取り込み
- 入退室を読み上げる設定、投稿者を読み上げる設定を追加 85f9483
- Merge branch 'main' of https://github.com/tetsuya-ki/discord-jtalkbot … … 5cd8515
- 接続しているギルド全ての文章を読み上げる設定を追加(read_all_guild) 3e2caa3

## 変更点

- 以下の設定を追加
  - `read_name`: 名前を読み上げるかどうか
  - `read_system_message`: メンバーのボイスチャンネルへの入退室を読み上げるかどうか
  - `read_all_guild`: すべてのギルドのメッセージを読み上げるかどうか